### PR TITLE
Fix oracle intersect-statement (SDO_RELATE)

### DIFF
--- a/Component/Drivers/Oracle.php
+++ b/Component/Drivers/Oracle.php
@@ -103,7 +103,7 @@ class Oracle extends DoctrineBaseDriver implements Geographic
      */
     public function getIntersectCondition($wkt, $geomFieldName, $srid, $sridTo)
     {
-        return "SDO_RELATE($wkt ,SDO_GEOMETRY(SDO_CS.TRANSFORM('$geomFieldName',$srid),$sridTo), 'mask=ANYINTERACT querytype=WINDOW') = 'TRUE'";
+        return "SDO_RELATE($geomFieldName, SDO_GEOMETRY('$wkt', $srid), 'mask=ANYINTERACT querytype=WINDOW') = 'TRUE'";
     }
 
     /**


### PR DESCRIPTION
This fixes the Oracle driver's intersect statement.
There is no need to transform the input geometry, as the srid is already provided by the specified column. Only the 'cutout'-geometry needs to specify a srid.