### PR TITLE
Fix/compatibility issue with parameters of getSelectQueryBuilder

### DIFF
--- a/Component/FeatureType.php
+++ b/Component/FeatureType.php
@@ -172,7 +172,7 @@ class FeatureType extends DataStore
      */
     public function getById($id, $srid = null)
     {
-        $rows = $this->getSelectQueryBuilder($srid)->setMaxResults(1)
+        $rows = $this->getSelectQueryBuilder(null,$srid)->setMaxResults(1)
             ->where($this->getUniqueId() . " = :id")
             ->setParameter('id', $id)
             ->execute()
@@ -431,14 +431,15 @@ class FeatureType extends DataStore
     /**
      * Get query builder prepared to select from the source table
      *
+     * @param array $fields
      * @param null $srid
      * @return QueryBuilder
      */
-    public function getSelectQueryBuilder($srid = null)
+    public function getSelectQueryBuilder(array $fields = array(),$srid = null)
     {
         $driver = $this->getDriver();
         $geomFieldCondition = $driver->getGeomAttributeAsWkt($this->geomField, $srid ? $srid : $this->getSrid());
-        $queryBuilder = parent::getSelectQueryBuilder();
+        $queryBuilder = parent::getSelectQueryBuilder($fields);
         $queryBuilder->addSelect($geomFieldCondition);
         return $queryBuilder;
     }

--- a/Component/FeatureType.php
+++ b/Component/FeatureType.php
@@ -346,7 +346,7 @@ class FeatureType extends DataStore
         $maxResults      = isset($criteria['maxResults']) ? intval($criteria['maxResults']) : self::MAX_RESULTS;
         $returnType      = isset($criteria['returnType']) ? $criteria['returnType'] : null;
         $srid            = isset($criteria['srid']) ? $criteria['srid'] : $this->getSrid();
-        $queryBuilder    = $this->getSelectQueryBuilder($srid);
+        $queryBuilder    = $this->getSelectQueryBuilder(null,$srid);
 
         $this->addCustomSearchCritera($queryBuilder, $criteria);
 

--- a/Component/FeatureType.php
+++ b/Component/FeatureType.php
@@ -374,8 +374,9 @@ class FeatureType extends DataStore
     {
         parent::addCustomSearchCritera($queryBuilder, $params);
         // add bounding geometry condition
-        if (!empty($params['intersect'])) {
-            $geometry = BaseDriver::roundGeometry($params['intersect'], 2);
+        if (!empty($params['intersect']) || !empty($params['intersectGeometry'])) {
+            $intersect = !empty($params['intersect']) ? $params['intersect'] : $params['intersectGeometry'];
+            $geometry = BaseDriver::roundGeometry($intersect, 2);
             if (!empty($params['srid'])) {
                 $sridFrom = $params['srid'];
             } else {

--- a/Component/FeatureType.php
+++ b/Component/FeatureType.php
@@ -374,9 +374,8 @@ class FeatureType extends DataStore
     {
         parent::addCustomSearchCritera($queryBuilder, $params);
         // add bounding geometry condition
-        if (!empty($params['intersect']) || !empty($params['intersectGeometry'])) {
-            $intersect = !empty($params['intersect']) ? $params['intersect'] : $params['intersectGeometry'];
-            $geometry = BaseDriver::roundGeometry($intersect, 2);
+        if (!empty($params['intersect'])) {
+            $geometry = BaseDriver::roundGeometry($params['intersect'], 2);
             if (!empty($params['srid'])) {
                 $sridFrom = $params['srid'];
             } else {

--- a/Component/FeatureType.php
+++ b/Component/FeatureType.php
@@ -172,7 +172,7 @@ class FeatureType extends DataStore
      */
     public function getById($id, $srid = null)
     {
-        $rows = $this->getSelectQueryBuilder(null,$srid)->setMaxResults(1)
+        $rows = $this->getSelectQueryBuilder(array(),$srid)->setMaxResults(1)
             ->where($this->getUniqueId() . " = :id")
             ->setParameter('id', $id)
             ->execute()
@@ -346,7 +346,7 @@ class FeatureType extends DataStore
         $maxResults      = isset($criteria['maxResults']) ? intval($criteria['maxResults']) : self::MAX_RESULTS;
         $returnType      = isset($criteria['returnType']) ? $criteria['returnType'] : null;
         $srid            = isset($criteria['srid']) ? $criteria['srid'] : $this->getSrid();
-        $queryBuilder    = $this->getSelectQueryBuilder(null,$srid);
+        $queryBuilder    = $this->getSelectQueryBuilder(array(),$srid);
 
         $this->addCustomSearchCritera($queryBuilder, $criteria);
 


### PR DESCRIPTION
There is a compatibility break between DataItem::getSelectQueryBuilder and FeatureType::getSelectQueryBuilder concerning their Parameters. This does not take place in PHP 7.2, but in PHP 7.0. Resolved in this branch.